### PR TITLE
Fix Status Bar Showing Application Menu of Dead Applications.

### DIFF
--- a/src/appmenu/appmenumodel.h
+++ b/src/appmenu/appmenumodel.h
@@ -123,6 +123,7 @@ private:
 
     //! current active window used
     WId m_currentWindowId = 0;
+    WId m_initialApplicationFromWindowId = -1;
     //! window that its menu initialization may be delayed
     WId m_delayedMenuWindowId = 0;
 


### PR DESCRIPTION
> If a window without global menus is foremost, then the Menu bar, when clicked into, shows menu items of already-gone last application

This has been fixed. I guess.

**But please test this before merging. I've tested this in my linux box but I don't know how it will work on BSD.**

**CC**: @probonopd 