### PR TITLE
Automatically Integrate User Application

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,10 @@ set(SRCS
     appmenu/utils_p.h
     actionsearch/actionsearch.h
     actionsearch/actionsearch.cpp
+    applicationwatcher/applicationwatcher.h
+    applicationwatcher/applicationwatcher_p.h
+    applicationwatcher/applicationwatcher.cpp
+    applicationwatcher/applicationwatcher_p.cpp
     qtsingleapplication/qtsingleapplication.h
     qtsingleapplication/qtsingleapplication.cpp
     qtsingleapplication/qtlocalpeer.cpp

--- a/src/applicationwatcher/applicationwatcher.cpp
+++ b/src/applicationwatcher/applicationwatcher.cpp
@@ -1,0 +1,26 @@
+#include "applicationwatcher.h"
+#include "applicationwatcher_p.h"
+
+ApplicationWatcher::ApplicationWatcher(const QString &rootPath, QObject *parent)
+	: QObject(parent) {
+	m_workerThread = new QThread;
+	m_workerThread->start();
+
+	m_privateImpl = new ApplicationWatcherPrivate(rootPath);
+	m_privateImpl->moveToThread(m_workerThread);	
+
+	connect(m_privateImpl, &ApplicationWatcherPrivate::insertEntry,
+		this, &ApplicationWatcher::insertEntry,
+		Qt::DirectConnection);
+	connect(m_privateImpl, &ApplicationWatcherPrivate::clearMenuRequested,
+		this, &ApplicationWatcher::clearMenuRequested,
+		Qt::DirectConnection);
+}
+
+ApplicationWatcher::~ApplicationWatcher() {
+	m_workerThread->quit();
+	m_workerThread->wait();
+
+	m_privateImpl->deleteLater();
+	m_workerThread->deleteLater();
+}

--- a/src/applicationwatcher/applicationwatcher.h
+++ b/src/applicationwatcher/applicationwatcher.h
@@ -1,0 +1,21 @@
+#ifndef APPLICATION_WATCHER_H_INCLUDED
+#define APPLICATION_WATCHER_H_INCLUDED
+
+#include <QObject>
+#include <QThread>
+
+class ApplicationWatcherPrivate;
+class ApplicationWatcher : public QObject {
+	Q_OBJECT
+public:
+	ApplicationWatcher(const QString&, QObject *parent = nullptr);
+	~ApplicationWatcher();
+Q_SIGNALS:
+	void insertEntry(const QString &title, const QString &path);
+	void clearMenuRequested();
+private:
+	QThread *m_workerThread;
+	ApplicationWatcherPrivate *m_privateImpl;
+};
+
+#endif // APPLICATION_WATCHER_H_INCLUDED

--- a/src/applicationwatcher/applicationwatcher_p.cpp
+++ b/src/applicationwatcher/applicationwatcher_p.cpp
@@ -1,0 +1,64 @@
+#include <QFileInfo>
+#include "applicationwatcher_p.h"
+
+ApplicationWatcherPrivate::ApplicationWatcherPrivate(const QString &rootPath, QObject *parent)
+	: QObject(parent) {
+	m_fsModel = new QFileSystemModel(this);
+	connect(m_fsModel, &QFileSystemModel::rowsInserted, this, &ApplicationWatcherPrivate::handleRowsInserted);
+	connect(m_fsModel, &QFileSystemModel::rowsRemoved, this, &ApplicationWatcherPrivate::handleRowsRemoved);
+	m_fsModel->setRootPath(rootPath);
+}
+
+ApplicationWatcherPrivate::~ApplicationWatcherPrivate() {
+	m_fsModel->deleteLater();
+}
+
+void ApplicationWatcherPrivate::handleRowsInserted(const QModelIndex &parentObj, int first, int last) {
+	for(auto i = first; i <= last; ++i) {
+		auto t = parentObj.child(i, /*column=*/0);
+		auto fileName = t.data().toString();
+		if(!fileName.toLower().endsWith(".app") && !fileName.toLower().endsWith(".appdir")) {
+			continue;
+		}
+
+		// The correct way to get the right name is to inspect some kind of metadata 
+		// in the AppDir or .app bundle, it's virtually impossible to find the Application
+		// name from filenames and can even be misleading sometimes.
+		QFileInfo fi(t.data().toString());
+                QString base = fi.completeBaseName(); 
+		Entry e;
+		e.title = base;
+	        e.path = m_fsModel->rootPath() + "/" + t.data().toString();
+		m_entries.append(e);
+		emit insertEntry(e.title, e.path);
+	}
+
+}
+
+void ApplicationWatcherPrivate::handleRowsRemoved(const QModelIndex &parentObj, int first, int last) {
+	/// This could be optimized more.
+	/// But the catch is once the entry is deleted from the filesystem we can't get the name 
+	/// of the file since it's already deleted so we should search for what's deleted and then
+	/// remove that and re-construct the whole menu.
+	/// I think there could be something we could do here.
+
+	(void)first;
+	(void)last;
+	(void)parentObj;	
+
+	/// Validate the entries and the filesystem and remove all that 
+	/// does not exist in the Filesystem.
+	for(auto i = 0; i < m_entries.size(); ++i) {
+		auto e = m_entries.at(i);
+		if(!QFileInfo::exists(e.path)) {
+			m_entries.removeAt(i);
+		}		
+	}
+
+	/// After removing the entry, reconstruct the menu.
+	emit clearMenuRequested();
+	for(auto i = 0; i < m_entries.size(); ++i) {
+		auto e = m_entries.at(i);
+		emit insertEntry(e.title, e.path);
+	}
+}

--- a/src/applicationwatcher/applicationwatcher_p.h
+++ b/src/applicationwatcher/applicationwatcher_p.h
@@ -1,0 +1,29 @@
+#ifndef APPLICATION_WATCHER_PRIVATE_INCLUDED
+#define APPLICATION_WATCHER_PRIVATE_INCLUDED
+
+#include <QObject>
+#include <QFileSystemModel>
+#include <QVector>
+
+class ApplicationWatcherPrivate : public QObject {
+	Q_OBJECT
+	struct Entry {
+		QString title,
+			path;
+		
+	};
+public:
+	ApplicationWatcherPrivate(const QString&, QObject *parent = nullptr);
+	~ApplicationWatcherPrivate();
+private Q_SLOTS:
+	void handleRowsInserted(const QModelIndex&, int, int);
+	void handleRowsRemoved(const QModelIndex&, int, int);
+Q_SIGNALS:
+	void insertEntry(const QString &title, const QString &path);
+	void clearMenuRequested();
+private:
+	QVector<Entry> m_entries;	
+	QFileSystemModel *m_fsModel;
+};
+
+#endif // APPLICATION_WATCHER_PRIVATE_INCLUDED

--- a/src/appmenuwidget.h
+++ b/src/appmenuwidget.h
@@ -33,6 +33,8 @@
 
 #include "actionsearch/actionsearch.h"
 
+#include "applicationwatcher/applicationwatcher.h"
+
 class AppMenuWidget : public QWidget
 {
     Q_OBJECT
@@ -73,6 +75,8 @@ public slots:
 
 private slots:
     void handleActivated(const QString&);
+    void insertIntoApplicationMenu(const QString&, const QString&);
+    void clearApplicationMenu();
 
 /// For Action Search
 private:
@@ -81,9 +85,11 @@ private:
 /// For System Main Menu.
 private:
     QMenu *m_systemMenu;
+    QMenu *m_applicationMenu;
     void integrateSystemMenu(QMenuBar*);
 
 private:
+    ApplicationWatcher *m_appWatcher;
     QWidget *searchLineWidget;
     QLineEdit *searchLineEdit;
     QCompleter *actionCompleter;


### PR DESCRIPTION
# Changes in this PR

* The ```~/Application``` is being watched and any changes is reflected in ```System -> User Applications``` menu.
* Only ```~/Application``` is being tracked, more directories can be tracked but requires a dedicated submenu for now.
* Use of dedicated Submenu ```User Applications``` for applications tracked in ```~/Application```
* For all other directories are only loaded on startup of the menu bar, in future we can scale this solution for all other directories.

For you to test the automatic integration I've only done this for user applications, i.e the apps in ```~/Applications``` are integrated into ```System -> User Applications```.